### PR TITLE
Improves Safari support, updates videoStream dependency from demo index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const port = 3000;
 
 // start capture
-const videoStream = require('raspberrypi-node-camera-web-streamer');
+const videoStream = require('./videoStream');
 videoStream.acceptConnections(app, {
         width: 1280,
         height: 720,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "webserver",
-  "version": "1.0.0",
+  "name": "raspberrypi-node-camera-web-streamer",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raspberrypi-node-camera-web-streamer",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "HTTP video streamer for raspberrypi.",
   "main": "index.js",
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -2,8 +2,7 @@
 <head>
 <title>Raspberry Pi - Camera Stream</title>
 </head>
-<body>
-<center><h1>Raspberry Pi - Camera Stream</h1></center>
-<center><img src="stream.mjpg" width="1366" height="768" /></center>
+<body style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background: #111;">
+<img src="stream.mjpg" style="position: fixed; top: 0px; left: 0px; right: 0px; height: 100%; width: calc(100% + 2px); object-fit: contain;">
 </body>
 </html>

--- a/videoStream.js
+++ b/videoStream.js
@@ -48,7 +48,7 @@ let videoStream = {
                     if(isVerbose)
                         console.log('Writing frame: '+frameData.length);
 
-                    res.write('--myboundary\nContent-Type: image/jpg\nContent-length: ${frameData.length}\n\n');
+                    res.write(`--myboundary\nContent-Type: image/jpg\nContent-length: ${frameData.length}\n\n`);
                     res.write(frameData, function(){
                         isReady = true;
                     });


### PR DESCRIPTION
# Improves Safari support, updates videoStream dependency from demo index.js
- Safari video streams generally did not work. This update fixes that.
- A problem with the way the videoStream.js library was being used by the demo project made it so that the demo didn't work correctly when cloned directly from the git repository. This update corrects that
- Presentation of the video in the demo index.js hosted page is much better and optimized for mobile (centered, dynamically resizes, dark background).